### PR TITLE
Removing internal from ProfiledSqlDbCommand

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2012 MiniProfiler.Nhibernate 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/MiniProfiler.NHibernate/Infrastructure/ProfiledSqlDbCommand.cs
+++ b/MiniProfiler.NHibernate/Infrastructure/ProfiledSqlDbCommand.cs
@@ -4,7 +4,7 @@ using StackExchange.Profiling.Data;
 
 namespace StackExchange.Profiling.NHibernate.Infrastructure
 {
-    internal class ProfiledSqlDbCommand : ProfiledDbCommand
+    public class ProfiledSqlDbCommand : ProfiledDbCommand
     {
         private readonly SqlCommand _sqlCommand;
 

--- a/MiniProfiler.NHibernate/MiniProfiler.NHibernate.csproj
+++ b/MiniProfiler.NHibernate/MiniProfiler.NHibernate.csproj
@@ -39,6 +39,10 @@
     <Reference Include="MiniProfiler">
       <HintPath>..\packages\MiniProfiler.2.1.0\lib\net40\MiniProfiler.dll</HintPath>
     </Reference>
+    <Reference Include="NHibernate, Version=3.3.1.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NHibernate.3.3.3.4001\lib\Net35\NHibernate.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/MiniProfiler.NHibernate/MiniProfiler.NHibernate.csproj
+++ b/MiniProfiler.NHibernate/MiniProfiler.NHibernate.csproj
@@ -39,9 +39,6 @@
     <Reference Include="MiniProfiler">
       <HintPath>..\packages\MiniProfiler.2.1.0\lib\net40\MiniProfiler.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate">
-      <HintPath>..\packages\NHibernate.3.2.0.4000\lib\Net35\NHibernate.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/MiniProfiler.NHibernate/packages.config
+++ b/MiniProfiler.NHibernate/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net40" />
   <package id="MiniProfiler" version="2.1.0" targetFramework="net40" />
-  <package id="NHibernate" version="3.2.0.4000" targetFramework="net40" />
+  <package id="NHibernate" version="3.3.3.4001" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
I added a license, support for nhibernate 3.3.3.4001 and removed the internal for the sqlcommand class. 

The reasoning behind it comes from setting a custom type from the SQLCommand properties for a custom type - this code would not compile since the command class is not visible.  

```
public void NullSafeSet(IDbCommand st, object value, int index, ISessionImplementor session)
            {
                var s = st as SqlCommand;

                if(s == null)
                {
                    var sz = st as StackExchange.Profiling.NHibernate.Infrastructure.ProfiledSqlDbCommand;
                    s = sz.SqlCommand;
                    if (s == null)
                    {
                        throw new NotImplementedException();
                    }
                }
                s.Parameters[index].SqlDbType = SqlDbType.Structured;
                s.Parameters[index].TypeName = "StringList";
                s.Parameters[index].Value = value;
            }

```
